### PR TITLE
fix(SA-582): create IAM roles (all of them) before trying to create K…

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -138,6 +138,7 @@ module "iam_roles" {
 
   depends_on = [
     aws_iam_policy.iam_policies
+    aws_iam_service_linked_role.aws_iam_service_linked_role
   ]
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -137,8 +137,8 @@ module "iam_roles" {
   }
 
   depends_on = [
-    aws_iam_policy.iam_policies
-    aws_iam_service_linked_role.aws_iam_service_linked_role
+    aws_iam_policy.iam_policies,
+    aws_iam_service_linked_role.aws_iam_service_linked_role,
   ]
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -138,7 +138,7 @@ module "iam_roles" {
 
   depends_on = [
     aws_iam_policy.iam_policies,
-    aws_iam_service_linked_role.aws_iam_service_linked_role,
+    aws_iam_service_linked_role.service_linked_roles,
   ]
 }
 

--- a/kms.tf
+++ b/kms.tf
@@ -91,6 +91,7 @@ module "kms_key" {
 
   depends_on = [
     module.kms_key_administrator
+    module.iam_roles
   ]
 
   providers = {

--- a/kms.tf
+++ b/kms.tf
@@ -90,8 +90,8 @@ module "kms_key" {
   tags                    = merge(local.tags, { "Name" = var.kms_key.key_alias })
 
   depends_on = [
-    module.kms_key_administrator
-    module.iam_roles
+    module.kms_key_administrator,
+    module.iam_roles,
   ]
 
   providers = {


### PR DESCRIPTION
…MS key with policy that depends on the roles
https://appvia.atlassian.net/browse/SA-582

* explicit dependency within kms_key for all IAM roles (modules.iam_roles)
* iam_roles explicit dependency on the linked roles

The net effect, kms_key is dependent on linked roles,and thus the roles will be created before KMS key within inline policy referring to the roles.

---
Clean workflow. Of course no plan - this is a module.